### PR TITLE
Allow primitive options to mitigate with zero shots / samples / shots_per_sample

### DIFF
--- a/qiskit_ibm_runtime/options/execution_options.py
+++ b/qiskit_ibm_runtime/options/execution_options.py
@@ -85,17 +85,17 @@ class ExecutionOptions:
         if shots is not None:
             if not isinstance(shots, Integral):
                 raise ValueError(f"shots must be None or an integer, not {type(shots)}")
-            if shots < 1:
+            if shots < 0:
                 raise ValueError("shots must be None or >= 1")
         if samples is not None:
             if not isinstance(samples, Integral):
                 raise ValueError(f"samples must be None or an integer, not {type(samples)}")
-            if samples < 1:
+            if samples < 0:
                 raise ValueError("samples must be None or >= 1")
         if shots_per_sample is not None:
             if not isinstance(shots_per_sample, Integral):
                 raise ValueError(
                     f"shots_per_sample must be None or an integer, not {type(shots_per_sample)}"
                 )
-            if shots_per_sample < 1:
+            if shots_per_sample < 0:
                 raise ValueError("shots_per_sample must be None or >= 1")


### PR DESCRIPTION
Change value validation for Primitive options for shots / shots_per_samples / samples.

### Summary
Value check of shots, etc. to enable more flexibility for primitive options.


### Details and comments
Reducing value checks from 1 to 0.

